### PR TITLE
Whitelist DigitalRiver img subdomain

### DIFF
--- a/trackers-whitelist.txt
+++ b/trackers-whitelist.txt
@@ -10,3 +10,4 @@ recs.richrelevance.com
 ! that appear to be only css/styling information
 ! Whitelist this until we can fix it
 |data:text$popup
+img.digitalriver.com

--- a/trackers-whitelist.txt
+++ b/trackers-whitelist.txt
@@ -11,3 +11,4 @@ recs.richrelevance.com
 ! Whitelist this until we can fix it
 |data:text$popup
 img.digitalriver.com
+user-images.githubusercontent.com


### PR DESCRIPTION
### Fixes: 

http://store.vmware.com/store/vmware/html/pbPage.fusion-vs-parallels?src=WWW_eBIZ_productpage_Fusion_Parallels_US

Also adds GitHub Images, so you can see the image below ;)

### Proof:
<img width="1278" alt="vmware_store_working" src="https://user-images.githubusercontent.com/873785/32506253-0ffcc682-c3b2-11e7-8a9e-a6296ab1295d.png">
