### PR TITLE
Whitelist: global.fncstatic.com to fix foxnews videos

### DIFF
--- a/trackers-whitelist.txt
+++ b/trackers-whitelist.txt
@@ -13,4 +13,4 @@ recs.richrelevance.com
 img.digitalriver.com
 user-images.githubusercontent.com
 a.slack-edge.com
-||global.fncstatic.com^$script,domain=foxnews.com|
+||global.fncstatic.com^$domain=foxnews.com

--- a/trackers-whitelist.txt
+++ b/trackers-whitelist.txt
@@ -13,3 +13,4 @@ recs.richrelevance.com
 img.digitalriver.com
 user-images.githubusercontent.com
 a.slack-edge.com
+akamaihd.net

--- a/trackers-whitelist.txt
+++ b/trackers-whitelist.txt
@@ -13,4 +13,4 @@ recs.richrelevance.com
 img.digitalriver.com
 user-images.githubusercontent.com
 a.slack-edge.com
-global.fncstatic.com
+||global.fncstatic.com^$script,domain=video.foxnews.com

--- a/trackers-whitelist.txt
+++ b/trackers-whitelist.txt
@@ -13,4 +13,4 @@ recs.richrelevance.com
 img.digitalriver.com
 user-images.githubusercontent.com
 a.slack-edge.com
-global.fncstatic.com^$domain=foxnews.com
+global.fncstatic.com/$domain=foxnews.com

--- a/trackers-whitelist.txt
+++ b/trackers-whitelist.txt
@@ -13,4 +13,4 @@ recs.richrelevance.com
 img.digitalriver.com
 user-images.githubusercontent.com
 a.slack-edge.com
-||global.fncstatic.com^$script,domain=video.foxnews.com
+||global.fncstatic.com^$script,domain=foxnews.com

--- a/trackers-whitelist.txt
+++ b/trackers-whitelist.txt
@@ -13,4 +13,4 @@ recs.richrelevance.com
 img.digitalriver.com
 user-images.githubusercontent.com
 a.slack-edge.com
-||global.fncstatic.com^$script,domain=foxnews.com
+||global.fncstatic.com^$script,domain=foxnews.com|

--- a/trackers-whitelist.txt
+++ b/trackers-whitelist.txt
@@ -13,4 +13,4 @@ recs.richrelevance.com
 img.digitalriver.com
 user-images.githubusercontent.com
 a.slack-edge.com
-||global.fncstatic.com^$domain=foxnews.com
+global.fncstatic.com^$domain=foxnews.com

--- a/trackers-whitelist.txt
+++ b/trackers-whitelist.txt
@@ -13,4 +13,4 @@ recs.richrelevance.com
 img.digitalriver.com
 user-images.githubusercontent.com
 a.slack-edge.com
-global.fncstatic.com/static/isa/app/*
+global.fncstatic.com

--- a/trackers-whitelist.txt
+++ b/trackers-whitelist.txt
@@ -13,4 +13,4 @@ recs.richrelevance.com
 img.digitalriver.com
 user-images.githubusercontent.com
 a.slack-edge.com
-akamaihd.net
+global.fncstatic.com

--- a/trackers-whitelist.txt
+++ b/trackers-whitelist.txt
@@ -13,4 +13,4 @@ recs.richrelevance.com
 img.digitalriver.com
 user-images.githubusercontent.com
 a.slack-edge.com
-global.fncstatic.com/$domain=foxnews.com
+global.fncstatic.com/static/isa/app/*


### PR DESCRIPTION
Adds `global.fncstatic.com` to whitelist to fix videos:
e.g. http://video.foxnews.com/v/5644525328001/?#sp=news-clips