### PR TITLE
whitelist over matching regex

### DIFF
--- a/trackers-whitelist.txt
+++ b/trackers-whitelist.txt
@@ -13,6 +13,7 @@ recs.richrelevance.com
 img.digitalriver.com
 user-images.githubusercontent.com
 a.slack-edge.com
-global.fncstatic.com^$domain=foxnews.com
+global.fncstatic.com
 s1.wp.com
+! need to fix regex matching in apb parser. Remove this after fixing
 /\\.com\\/[0-9]{2,9}\\/$/$script,stylesheet,third-party,xmlhttprequest

--- a/trackers-whitelist.txt
+++ b/trackers-whitelist.txt
@@ -13,5 +13,5 @@ recs.richrelevance.com
 img.digitalriver.com
 user-images.githubusercontent.com
 a.slack-edge.com
-global.fncstatic.com
+global.fncstatic.com^$domain=foxnews.com
 s1.wp.com

--- a/trackers-whitelist.txt
+++ b/trackers-whitelist.txt
@@ -15,3 +15,4 @@ user-images.githubusercontent.com
 a.slack-edge.com
 global.fncstatic.com^$domain=foxnews.com
 s1.wp.com
+/\\.com\\/[0-9]{2,9}\\/$/$script,stylesheet,third-party,xmlhttprequest


### PR DESCRIPTION
Our abp module is over matching on some regex entries. This one is particularly bad. 

Some test sites that are currently broken:
http://urbanartassociation.com/
http://thepioneerwoman.com/cooking/