### PR TITLE
fix nytimes

### DIFF
--- a/trackers-whitelist-temporary.txt
+++ b/trackers-whitelist-temporary.txt
@@ -1,2 +1,1 @@
 businessinsider.com
-nytimes.com

--- a/trackers-whitelist.txt
+++ b/trackers-whitelist.txt
@@ -15,7 +15,7 @@ user-images.githubusercontent.com
 a.slack-edge.com
 global.fncstatic.com
 s1.wp.com
-||https://contextual.media.net/bidexchange.js^$domain=nytimes.com
+||contextual.media.net/bidexchange.js^$domain=nytimes.com
 ! Regex entries. Need to fix regex matching in apb parser. Remove this after fixing
 /\.com\/[0-9]{2,9}\/$/$script,stylesheet,third-party,xmlhttprequest
 /\:\/\/[a-z0-9]{5,40}\.com\/[0-9]{2,9}\/$/$script,stylesheet,third-party,xmlhttprequest

--- a/trackers-whitelist.txt
+++ b/trackers-whitelist.txt
@@ -15,6 +15,7 @@ user-images.githubusercontent.com
 a.slack-edge.com
 global.fncstatic.com
 s1.wp.com
+||https://contextual.media.net/bidexchange.js^$domain=nytimes.com
 ! Regex entries. Need to fix regex matching in apb parser. Remove this after fixing
 /\.com\/[0-9]{2,9}\/$/$script,stylesheet,third-party,xmlhttprequest
 /\:\/\/[a-z0-9]{5,40}\.com\/[0-9]{2,9}\/$/$script,stylesheet,third-party,xmlhttprequest


### PR DESCRIPTION
Remove nytimes.com from temp whitelist and whitelist individual tracker.