### PR TITLE
xhcdn whitelist

### DIFF
--- a/trackers-whitelist.txt
+++ b/trackers-whitelist.txt
@@ -17,6 +17,10 @@ global.fncstatic.com
 s1.wp.com
 ||contextual.media.net/bidexchange.js^$domain=nytimes.com
 ||google-analytics.com/analytics.js$domain=raspberrypi.org
+! these exist in the easylist whitelist but the xhcdn.com is too short to go in the bloomfilter
+! remove these after fixing the problem
+||xhcdn.com^$script,domain=xhamster.com
+||xhcdn.com^*/shader/$xmlhttprequest,domain=xhamster.com
 ! Regex entries. Need to fix regex matching in apb parser. Remove this after fixing
 /\.com\/[0-9]{2,9}\/$/$script,stylesheet,third-party,xmlhttprequest
 /\:\/\/[a-z0-9]{5,40}\.com\/[0-9]{2,9}\/$/$script,stylesheet,third-party,xmlhttprequest


### PR DESCRIPTION
Reported on [reddit](https://www.reddit.com/r/duckduckgo/comments/7mn3pk/ddg_firefox_addon_not_compatible_with_xhamster/)
Looks like an abp parser bug that I'll need to spend more time looking into so I'll add these to the whitelist for now.