### PR TITLE
whitelist calbanktrust

### DIFF
--- a/trackers-whitelist-temporary.txt
+++ b/trackers-whitelist-temporary.txt
@@ -5,3 +5,5 @@ redmart.com
 wrh.noaa.gov
 wwwnew.testout.com
 idnes.cz
+calbanktrust.com
+securentry.calbanktrust.com


### PR DESCRIPTION
From user feedback- 

"----URL is https://www.calbanktrust.com/

I would love to keep this extension installed, but I cannot access my company bank account. It will not allow login, despite having whitelisted all of the visible sites shown on the way through user login."