### PR TITLE
Add three sites to the whitelist

### DIFF
--- a/trackers-whitelist.txt
+++ b/trackers-whitelist.txt
@@ -19,6 +19,7 @@ s1.wp.com
 ||google-analytics.com/analytics.js$domain=raspberrypi.org
 ||s3.amazonaws.com
 ||static.polldaddy.com
+||i.polldaddy.com
 ! easyprivacy blocks these and breaks the site
 ||ssl.gstatic.com$domain=analytics.google.com
 ||csi.gstatic.com$domain=analytics.google.com

--- a/trackers-whitelist.txt
+++ b/trackers-whitelist.txt
@@ -17,6 +17,7 @@ global.fncstatic.com
 s1.wp.com
 ||contextual.media.net/bidexchange.js^$domain=nytimes.com
 ||google-analytics.com/analytics.js$domain=raspberrypi.org
+||s3.amazonaws.com
 ! easyprivacy blocks these and breaks the site
 ||ssl.gstatic.com$domain=analytics.google.com
 ||csi.gstatic.com$domain=analytics.google.com

--- a/trackers-whitelist.txt
+++ b/trackers-whitelist.txt
@@ -21,7 +21,7 @@ s1.wp.com
 ||static.polldaddy.com
 ||i.polldaddy.com
 ! causes the page to ininitely refresh on canadiantire.ca
-||omtrdc.net$domain=canadiantire.ca
+omtrdc.net^$domain=canadiantire.ca
 ! easyprivacy blocks these and breaks the site
 ||ssl.gstatic.com$domain=analytics.google.com
 ||csi.gstatic.com$domain=analytics.google.com

--- a/trackers-whitelist.txt
+++ b/trackers-whitelist.txt
@@ -18,6 +18,7 @@ s1.wp.com
 ||contextual.media.net/bidexchange.js^$domain=nytimes.com
 ||google-analytics.com/analytics.js$domain=raspberrypi.org
 ||s3.amazonaws.com
+||static.polldaddy.com
 ! easyprivacy blocks these and breaks the site
 ||ssl.gstatic.com$domain=analytics.google.com
 ||csi.gstatic.com$domain=analytics.google.com

--- a/trackers-whitelist.txt
+++ b/trackers-whitelist.txt
@@ -20,6 +20,8 @@ s1.wp.com
 ||s3.amazonaws.com
 ||static.polldaddy.com
 ||i.polldaddy.com
+! causes the page to ininitely refresh on canadiantire.ca
+||cantire.d2.sc.omtrdc.net
 ! easyprivacy blocks these and breaks the site
 ||ssl.gstatic.com$domain=analytics.google.com
 ||csi.gstatic.com$domain=analytics.google.com

--- a/trackers-whitelist.txt
+++ b/trackers-whitelist.txt
@@ -21,7 +21,7 @@ s1.wp.com
 ||static.polldaddy.com
 ||i.polldaddy.com
 ! causes the page to ininitely refresh on canadiantire.ca
-||cantire.d2.sc.omtrdc.net
+||omtrdc.net$domain=canadiantire.ca
 ! easyprivacy blocks these and breaks the site
 ||ssl.gstatic.com$domain=analytics.google.com
 ||csi.gstatic.com$domain=analytics.google.com


### PR DESCRIPTION
Does the following:

- don't count `s3.amazonaws.com` as a tracker (it's used as a CDN e.g. here: https://www.vuoriclothing.com/ - nothing visually breaks, but the console gives JS errors)
- don't count Polldaddy polls as a tracker (we didn't have a sample site, but I found this: http://snippets.wikidot.com/code:polldaddy - scroll down to "in action")
- fix canadatyres.ca - without this whitelist entry, the following page refreshes every 5-10 seconds: http://www.canadiantire.ca/en/pdp/rust-oleum-stone-effects-step-3-counter-top-coating-0490270p.html#Reviews