### PR TITLE
whitelist nav-analytics to fix bbci player.

### DIFF
--- a/trackers-whitelist.txt
+++ b/trackers-whitelist.txt
@@ -39,3 +39,4 @@ omtrdc.net^$domain=canadiantire.ca
 /\.com\/[0-9]{2,9}\/$/$script,stylesheet,third-party,xmlhttprequest
 /\:\/\/[a-z0-9]{5,40}\.com\/[0-9]{2,9}\/$/$script,stylesheet,third-party,xmlhttprequest
 /\:\/\/[a-z0-9]{5,}\.com\/[A-Za-z0-9]{3,}\/$/$script,stylesheet,third-party,xmlhttprequest
+||nav.files.bbci.co.uk/nav-analytics/*$script,domain=bbc.com|bbc.co.uk


### PR DESCRIPTION
https://www.bbc.co.uk/iplayer/episode/b09q4f9v/spiral-series-6-episode-10
Before:
![chrome_2018-02-01_18-53-59](https://user-images.githubusercontent.com/4481594/35709602-48aad5b0-0781-11e8-8bfc-fce2471b422d.png)

After:
![virtualbox_2018-02-01_18-53-17](https://user-images.githubusercontent.com/4481594/35709607-4f7c6124-0781-11e8-86b0-0bdfda2de4a8.png)
