### PR TITLE
unblock geolock request on abc

### DIFF
--- a/trackers-whitelist.txt
+++ b/trackers-whitelist.txt
@@ -39,3 +39,4 @@ omtrdc.net^$domain=canadiantire.ca
 /\.com\/[0-9]{2,9}\/$/$script,stylesheet,third-party,xmlhttprequest
 /\:\/\/[a-z0-9]{5,40}\.com\/[0-9]{2,9}\/$/$script,stylesheet,third-party,xmlhttprequest
 /\:\/\/[a-z0-9]{5,}\.com\/[A-Za-z0-9]{3,}\/$/$script,stylesheet,third-party,xmlhttprequest
+||edgedatg.com^$script,domain=abc.go.com


### PR DESCRIPTION
This fixes video playback on abc.go.com.

Before: 
![image](https://user-images.githubusercontent.com/4481594/35709860-8fb50a2e-0782-11e8-8b52-5ef359b24b33.png)

After:
![image](https://user-images.githubusercontent.com/4481594/35709876-a55ef63c-0782-11e8-9117-2e939a4f2fb8.png)
