### PR TITLE
remove business insider from whitelist

### DIFF
--- a/trackers-whitelist-temporary.txt
+++ b/trackers-whitelist-temporary.txt
@@ -1,4 +1,3 @@
-businessinsider.com
 open.spotify.com
 messenger.com
 redmart.com


### PR DESCRIPTION
Site is no longer broken with privacy protection enabled, so remove it from the temporary whitelist.