### PR TITLE
don't block first party yahoo request on yahoo domains.

### DIFF
--- a/trackers-whitelist.txt
+++ b/trackers-whitelist.txt
@@ -51,6 +51,7 @@ omtrdc.net^$domain=canadiantire.ca
 ||auth.9c9media.ca^$domain=tsn.ca
 ||fastly.net^$image,domain=cbs.com 
 ||fastly.net^$script,domain=cbs.com
+||yimg.com^$domain=yahoo.com|yahoo.co.jp|flickr.com|yuilibrary.com|tumblr.com|yahoostudios.com
 
 ! ###################################################
 ! #      End of manually added filter section       #


### PR DESCRIPTION
We were blocking yahoo on their own page, which isn't the correct behavior. Temporarily whitelisting the request while we update internals to fix.