### PR TITLE
whitelist chefkoch cdn on chefkoch.de

### DIFF
--- a/trackers-whitelist.txt
+++ b/trackers-whitelist.txt
@@ -55,6 +55,7 @@ omtrdc.net^$domain=canadiantire.ca
 ||static.tacdn.com
 ||yimg.com^$domain=yahoo.com|yahoo.co.jp|flickr.com|yuilibrary.com|tumblr.com|yahoostudios.com
 ||adnxs.com^$domain=bild.de
+||chefkoch-cdn.de^$domain=chefkoch.de
 
 ! ###################################################
 ! #      End of manually added filter section       #


### PR DESCRIPTION
Fix video playback on chefkoch.de. Check https://www.chefkoch.de/video/artikel/1213,0/Chefkoch/Brot-und-Broetchen-backen-und-schleifen.html to see fix.