### PR TITLE
fix youtube embedded players blocked by wide easylist rules

### DIFF
--- a/trackers-whitelist.txt
+++ b/trackers-whitelist.txt
@@ -56,6 +56,7 @@ omtrdc.net^$domain=canadiantire.ca
 ||yimg.com^$domain=yahoo.com|yahoo.co.jp|flickr.com|yuilibrary.com|tumblr.com|yahoostudios.com
 ||adnxs.com^$domain=bild.de
 ||chefkoch-cdn.de^$domain=chefkoch.de
+||youtube.com^$script,stylesheet
 
 ! ###################################################
 ! #      End of manually added filter section       #


### PR DESCRIPTION
EasyList has some block rules that are overly wide and blocking all third party content on arbitrary websites (see https://github.com/easylist/easylist/blob/master/easylist/easylist_specific_block.txt#L5509).

A lot of these websites are using embedded youtube videos, which are broken by the above rule. This PR unbreaks embedded youtube videos.