### PR TITLE
widen skynews whitelisted cdn (e3.365dm.com) to accomodate other sky …

### DIFF
--- a/trackers-whitelist.txt
+++ b/trackers-whitelist.txt
@@ -51,7 +51,7 @@ omtrdc.net^$domain=canadiantire.ca
 ||auth.9c9media.ca^$domain=tsn.ca
 ||fastly.net^$image,domain=cbs.com 
 ||fastly.net^$script,domain=cbs.com
-||e3.365dm.com^$image
+||365dm.com^$image
 ||static.tacdn.com
 ||yimg.com^$domain=yahoo.com|yahoo.co.jp|flickr.com|yuilibrary.com|tumblr.com|yahoostudios.com
 ||adnxs.com^$domain=bild.de


### PR DESCRIPTION
…sites, such as skysports.

This specifically fixes images on www.skysports.com/football:

![image](https://user-images.githubusercontent.com/4481594/37317269-43775500-263a-11e8-8f1b-9b6747f986cf.png)
