### PR TITLE
remove spotify from temporary whitelist

### DIFF
--- a/trackers-whitelist-temporary.txt
+++ b/trackers-whitelist-temporary.txt
@@ -1,4 +1,3 @@
-open.spotify.com
 messenger.com
 redmart.com
 wrh.noaa.gov


### PR DESCRIPTION
This was actually solved by https://github.com/duckduckgo/abp-filter-parser/pull/4.

In order to see locally, make sure to `npm update abp-filter-parser` followed by `npm install` from within the extension directory to get the latest.