### PR TITLE
whitelist pixel on spiegel.de to prevent adblock warning.

### DIFF
--- a/trackers-whitelist.txt
+++ b/trackers-whitelist.txt
@@ -57,6 +57,7 @@ omtrdc.net^$domain=canadiantire.ca
 ||adnxs.com^$domain=bild.de
 ||chefkoch-cdn.de^$domain=chefkoch.de
 ||youtube.com^$script,stylesheet
+||ad.doubleclick.net/ddm/ad/$image,domain=spiegel.de
 
 ! ###################################################
 ! #      End of manually added filter section       #


### PR DESCRIPTION
Before:
![image](https://user-images.githubusercontent.com/4481594/37423112-662d145e-2793-11e8-8914-9d592b95f4b2.png)

After:
![image](https://user-images.githubusercontent.com/4481594/37423139-7a923c3a-2793-11e8-91ee-d3e1e7b9384a.png)
