### PR TITLE
unblock 247 live chat

### DIFF
--- a/trackers-whitelist.txt
+++ b/trackers-whitelist.txt
@@ -57,6 +57,7 @@ omtrdc.net^$domain=canadiantire.ca
 ||adnxs.com^$domain=bild.de
 ||chefkoch-cdn.de^$domain=chefkoch.de
 ||youtube.com^$script,stylesheet
+||d1af033869koo7.cloudfront.net/*/247px.js$script
 
 ! ###################################################
 ! #      End of manually added filter section       #


### PR DESCRIPTION
Live chat was being blocked on a handful of sites, including capital one and best buy. This unblocks it.

capital one before: 
![image](https://user-images.githubusercontent.com/4481594/37425561-278fb826-279a-11e8-87c0-2ef470670fb6.png)

capital one after:
![image](https://user-images.githubusercontent.com/4481594/37425501-f172d57a-2799-11e8-813d-a09aee6cc481.png)

more info on best buy here: https://github.com/uBlockOrigin/uAssets/blob/master/filters/unbreak.txt#L813