### PR TITLE
Fix mailchimp newsletter sign up forms

### DIFF
--- a/trackers-whitelist.txt
+++ b/trackers-whitelist.txt
@@ -58,6 +58,7 @@ omtrdc.net^$domain=canadiantire.ca
 ||youtube.com^$script,stylesheet
 ||ad.doubleclick.net/ddm/ad/$image,domain=spiegel.de
 ||d1af033869koo7.cloudfront.net/*/247px.js$script
+||list-manage.com/subscribe
 
 ! ###################################################
 ! #      End of manually added filter section       #


### PR DESCRIPTION
We were identifying list-manage.com domain as mailchimp and blocking request to it. This was causing newsletter sign up forms to break. This whitelists the subscription path and unbreaks those forms.

I've been using the form found at the bottom of a-d-o.com to test.