### PR TITLE
fix adblock warning on history.com, aetv.com, mylifetime.com, etc

### DIFF
--- a/trackers-whitelist.txt
+++ b/trackers-whitelist.txt
@@ -58,6 +58,8 @@ omtrdc.net^$domain=canadiantire.ca
 ||youtube.com^$script,stylesheet
 ||ad.doubleclick.net/ddm/ad/$image,domain=spiegel.de
 ||d1af033869koo7.cloudfront.net/*/247px.js$script
+! blocking this was breaking video players on dozens of network tv sites
+||c.amazon-adsystem.com/aax2/apstag.js
 
 ! ###################################################
 ! #      End of manually added filter section       #


### PR DESCRIPTION
We were blocking a request to amazon that caused a ton of streaming sites to detect adblock usage and tell you to turn off adblock. There seems to be a streaming framework that a lot of sites are using (at least all sites on A+E networks) that uses this same method of detection, so I didn't limit the rule to a specific list of sites.

To test, try watching one of the following videos:
https://www.history.com/shows/swamp-people/season-9/episode-11
https://www.mylifetime.com/shows/glam-masters/season-1/episode-7

Before:
![image](https://user-images.githubusercontent.com/4481594/38698857-73262b54-3e64-11e8-8834-4eff18374960.png)

After:
![image](https://user-images.githubusercontent.com/4481594/38698874-7f14312c-3e64-11e8-9b06-7932e2021867.png)
