### PR TITLE
unbreak search on tennislink.usta.com

### DIFF
--- a/trackers-whitelist.txt
+++ b/trackers-whitelist.txt
@@ -61,6 +61,7 @@ omtrdc.net^$domain=canadiantire.ca
 ||list-manage.com/subscribe
 ! blocking this was breaking video players on dozens of network tv sites
 ||c.amazon-adsystem.com/aax2/apstag.js
+||2o7.net^$image,domain=tennislink.usta.com
 
 ! ###################################################
 ! #      End of manually added filter section       #


### PR DESCRIPTION
URL is http://tennislink.usta.com/Tournaments/Schedule/Search.aspx

Before fix, clicking search button doesn't do anything. After fix, clicking search button works as expected.