### PR TITLE
unbreak streaming on tntdrama.com

### DIFF
--- a/trackers-whitelist.txt
+++ b/trackers-whitelist.txt
@@ -61,6 +61,7 @@ omtrdc.net^$domain=canadiantire.ca
 ||list-manage.com/subscribe
 ! blocking this was breaking video players on dozens of network tv sites
 ||c.amazon-adsystem.com/aax2/apstag.js
+||moatads.com/freewheel*/MoatFreeWheelJSPEM.js^$domain=tntdrama.com
 
 ! ###################################################
 ! #      End of manually added filter section       #


### PR DESCRIPTION
URL is http://www.tntdrama.com/watchtnt/east

Before fix: video stream doesn't load from time to time (not always, only when whatever is on is using moat ads)
After fix: video stream loads consistently.