### PR TITLE
temporarily allow gpt.js on theatlantic.com to avoid paywall.

### DIFF
--- a/trackers-whitelist.txt
+++ b/trackers-whitelist.txt
@@ -61,6 +61,9 @@ omtrdc.net^$domain=canadiantire.ca
 ||list-manage.com/subscribe
 ! blocking this was breaking video players on dozens of network tv sites
 ||c.amazon-adsystem.com/aax2/apstag.js
+! temporarily whitelist gpt on theatlantic to avoid paywall.
+! will revisit when solvable by script injection.
+||googletagservices.com/tag/js/gpt.js^$domain=theatlantic.com
 
 ! ###################################################
 ! #      End of manually added filter section       #


### PR DESCRIPTION
This is an odd one. This site is detecting our surrogate gpt.js code, and redirecting to a paywall if detected. A better solution will be possible when we implement script injection.

URL is https://www.theatlantic.com/magazine/archive/2018/05/realitys-end/556877/

Before fix: After about 5 seconds, page redirects to paywall
After fix: no paywall redirect