### PR TITLE
Avoid adblock wall on aftonbladet.se

### DIFF
--- a/trackers-whitelist.txt
+++ b/trackers-whitelist.txt
@@ -61,6 +61,7 @@ omtrdc.net^$domain=canadiantire.ca
 ||list-manage.com/subscribe
 ! blocking this was breaking video players on dozens of network tv sites
 ||c.amazon-adsystem.com/aax2/apstag.js
+||ib.adnxs.com/ut^$domain=aftonbladet.se
 
 ! ###################################################
 ! #      End of manually added filter section       #


### PR DESCRIPTION
Before: site blocked by adblock warning:
![image](https://user-images.githubusercontent.com/4481594/39458530-5ee7d166-4cc3-11e8-9d70-c2f29a29d875.png)

After: site usable:
![image](https://user-images.githubusercontent.com/4481594/39458579-a6c56520-4cc3-11e8-9049-8271fb9dc0f4.png)
