### PR TITLE
unbreak sites with maps hosted on developers.google.com

### DIFF
--- a/trackers-whitelist.txt
+++ b/trackers-whitelist.txt
@@ -61,6 +61,8 @@ omtrdc.net^$domain=canadiantire.ca
 ||list-manage.com/subscribe
 ! blocking this was breaking video players on dozens of network tv sites
 ||c.amazon-adsystem.com/aax2/apstag.js
+! many sites use maps and stylesheets hosted on developers.google.com
+||developers.google.com/maps^$stylesheet,script
 
 ! ###################################################
 ! #      End of manually added filter section       #


### PR DESCRIPTION
A lot of sites use default stylesheets and scripts for their embedded google maps. These are hosted on developers.google.com. A couple of example requests:
`https://developers.google.com/maps/documentation/javascript/examples/markerclusterer/markerclusterer.js`
`https://developers.google.com/maps/documentation/javascript/examples/default.css?csw=1`

Others may be found at: https://publicwww.com/websites/%22https%3A%2F%2Fdevelopers.google.com%2Fmaps%2Fdocumentation%2Fjavascript%2F%22/.

This simply allows those request to go through.