### PR TITLE
unbreak kiplinger.com

### DIFF
--- a/trackers-whitelist.txt
+++ b/trackers-whitelist.txt
@@ -61,6 +61,7 @@ omtrdc.net^$domain=canadiantire.ca
 ||list-manage.com/subscribe
 ! blocking this was breaking video players on dozens of network tv sites
 ||c.amazon-adsystem.com/aax2/apstag.js
+||2o7.net^$image,domain=kiplinger.com
 
 ! ###################################################
 ! #      End of manually added filter section       #


### PR DESCRIPTION
Blocking the request to 2o7.net was breaking this site.

URL is: https://www.kiplinger.com/

Before: Nothing could be clicked.

After: Site works as it should.