### PR TITLE
fix embedded yandex maps

### DIFF
--- a/trackers-whitelist.txt
+++ b/trackers-whitelist.txt
@@ -61,6 +61,8 @@ omtrdc.net^$domain=canadiantire.ca
 ||list-manage.com/subscribe
 ! blocking this was breaking video players on dozens of network tv sites
 ||c.amazon-adsystem.com/aax2/apstag.js
+! unblock embedded yandex maps
+||api-maps.yandex.ru^$script,image
 
 ! ###################################################
 ! #      End of manually added filter section       #


### PR DESCRIPTION
Disconnect list is causing us to block all third-party requests to yandex.ru, including maps. This allows embedded yandex maps to function.

URL is: https://chekalskiy.ru/slutsky/