### PR TITLE
whitelist yandex image cdn

### DIFF
--- a/trackers-whitelist.txt
+++ b/trackers-whitelist.txt
@@ -61,6 +61,8 @@ omtrdc.net^$domain=canadiantire.ca
 ||list-manage.com/subscribe
 ! blocking this was breaking video players on dozens of network tv sites
 ||c.amazon-adsystem.com/aax2/apstag.js
+! allow images hosted on yandex cdn to load
+||img-fotki.yandex.ru^$image
 
 ! ###################################################
 ! #      End of manually added filter section       #


### PR DESCRIPTION
Yandex rule in disconnect list is causing us to block images hosted on yandex's cdn (img-fotki.yandex.ru). Seems to be relatively common (https://publicwww.com/websites/%22img-fotki.yandex.ru%22/).

URL is: http://nnm-club.me/