### PR TITLE
unblock internetbrands appointment form

### DIFF
--- a/trackers-whitelist.txt
+++ b/trackers-whitelist.txt
@@ -61,6 +61,8 @@ omtrdc.net^$domain=canadiantire.ca
 ||list-manage.com/subscribe
 ! blocking this was breaking video players on dozens of network tv sites
 ||c.amazon-adsystem.com/aax2/apstag.js
+! unblock popular embedded appointment form
+||smbleads.internetbrands.com/v1/$script,stylesheet
 
 ! ###################################################
 ! #      End of manually added filter section       #


### PR DESCRIPTION
Disconnect identifies internetbrands.com as an advertiser, which is causing us to block all third party requests. This causes a popular appointment form to break (16k sites using it, mostly local salons/dentists/doctors. see https://publicwww.com/websites/smbleads.internetbrands.com%2Fv1%2Fjs/).

URL is: https://loshoptometry.com/appointment-request

Before: 
![image](https://user-images.githubusercontent.com/4481594/39459647-081e7d0a-4ccb-11e8-8fea-0667b2953777.png)

After:
![image](https://user-images.githubusercontent.com/4481594/39459652-10dcb39e-4ccb-11e8-9991-9e526bdb8f89.png)
