### PR TITLE
fix delltechnologiesworld.com

### DIFF
--- a/trackers-whitelist.txt
+++ b/trackers-whitelist.txt
@@ -61,6 +61,7 @@ omtrdc.net^$domain=canadiantire.ca
 ||list-manage.com/subscribe
 ! blocking this was breaking video players on dozens of network tv sites
 ||c.amazon-adsystem.com/aax2/apstag.js
+||tt.omtrdc.net^$script,domain=delltechnologiesworld.com
 
 ! ###################################################
 ! #      End of manually added filter section       #


### PR DESCRIPTION


URL is: https://www.delltechnologiesworld.com/live.htm?cmp=dew18_live_promo_dellhp&dgc=IR&cid=dtwaprilbanner&lid=B1&ref=hbn

Before:
![chrome_2018-04-30_23-52-21](https://user-images.githubusercontent.com/4481594/39460490-dc41cdc0-4cd1-11e8-9c5d-fd89197c6bf0.png)

After:
![image](https://user-images.githubusercontent.com/4481594/39460504-fb6ede9a-4cd1-11e8-8995-1402849f898d.png)
