### PR TITLE
Fix Bethesda Login

### DIFF
--- a/trackers-whitelist.txt
+++ b/trackers-whitelist.txt
@@ -77,6 +77,7 @@ omtrdc.net^$domain=canadiantire.ca
 ! will revisit when solvable by script injection.
 ||googletagservices.com/tag/js/gpt.js^$domain=theatlantic.com
 ||moatads.com/freewheel*/MoatFreeWheelJSPEM.js^$domain=tntdrama.com
+||googletagmanager.com/gtm.js$script,domain=account.bethesda.net
 
 ! ###################################################
 ! #      End of manually added filter section       #


### PR DESCRIPTION
Blocking googletagmanager throws an error on bethesda's login page, causing the page to be blank.

URL is: https://account.bethesda.net/en/login

Before: 
![image](https://user-images.githubusercontent.com/4481594/39558231-dbab1882-4e5a-11e8-89b2-2b31da64db50.png)

After:
![virtualbox_2018-05-02_22-41-54](https://user-images.githubusercontent.com/4481594/39558238-e6093110-4e5a-11e8-9d9f-b48d203ed162.png)
