### PR TITLE
unblock channeladvisor image cdn everywhere, fix bjs.com

### DIFF
--- a/trackers-whitelist.txt
+++ b/trackers-whitelist.txt
@@ -77,6 +77,10 @@ omtrdc.net^$domain=canadiantire.ca
 ! will revisit when solvable by script injection.
 ||googletagservices.com/tag/js/gpt.js^$domain=theatlantic.com
 ||moatads.com/freewheel*/MoatFreeWheelJSPEM.js^$domain=tntdrama.com
+! unblock channeladvisor image cdn
+||richmedia.channeladvisor.com/ImageDelivery/imageService^$image
+! fix broken styles on bjs.com
+||hlserve.com/Delivery/ClientPaths/Library/hook.js^$domain=bjs.com
 
 ! ###################################################
 ! #      End of manually added filter section       #


### PR DESCRIPTION
Entity list blocks all third party requests to channeladvisor.com, including images hosted on their cdn. This was causing images to not load on bjs.com, among other sites.

Additionally unblock js request on bjs.com that was breaking the site.

URL is: https://www.bjs.com/

Before: 
![image](https://user-images.githubusercontent.com/4481594/39560626-a0dbb12c-4e6d-11e8-8b63-e8a55abdd6ef.png)


After:
![image](https://user-images.githubusercontent.com/4481594/39560637-af58eb0c-4e6d-11e8-9807-652a81ed7433.png)
