### PR TITLE
fix ebay-kleinanzeigen.de in safari

### DIFF
--- a/trackers-whitelist.txt
+++ b/trackers-whitelist.txt
@@ -79,6 +79,8 @@ omtrdc.net^$domain=canadiantire.ca
 ! will revisit when solvable by script injection.
 ||googletagservices.com/tag/js/gpt.js^$domain=theatlantic.com
 ||moatads.com/freewheel*/MoatFreeWheelJSPEM.js^$domain=tntdrama.com
+! fix search and image loading in safari
+||script.ioam.de/iam.js$domain=ebay-kleinanzeigen.de
 
 ! ###################################################
 ! #      End of manually added filter section       #


### PR DESCRIPTION
Search field was breaking due to this request being blocked.

URL is: www.ebay-kleinanzeigen.de

Start typing a zip code in the center search field (for instance, type 681). Autocomplete menu should appear.