### PR TITLE
whitelist bank sites that have been reported to have broken logins

### DIFF
--- a/trackers-whitelist-temporary.txt
+++ b/trackers-whitelist-temporary.txt
@@ -3,7 +3,6 @@ redmart.com
 wrh.noaa.gov
 wwwnew.testout.com
 idnes.cz
-! bank websites reported broken
 calbanktrust.com
 fidelity.com
 vanguard.com

--- a/trackers-whitelist-temporary.txt
+++ b/trackers-whitelist-temporary.txt
@@ -3,5 +3,20 @@ redmart.com
 wrh.noaa.gov
 wwwnew.testout.com
 idnes.cz
+! bank websites reported broken
 calbanktrust.com
-securentry.calbanktrust.com
+fidelity.com
+vanguard.com
+mebank.com.au
+wellsfargo.com
+zionsbank.com
+bankofscotland.co.uk
+amegybank.com
+suntrust.com
+tdbank.com
+inlandbank.com
+bank.barclays.co.uk
+capitalone.com
+onlinebanking.nationwide.co.uk
+nbarizona.com
+sberbank.ru


### PR DESCRIPTION
Many online banking portals use fingerprinting techniques to help with fraud detection. These sites are difficult if not impossible to debug without valid logins. Add list of sites reported broken to temporary whitelist while we decide on a strategy moving forward.

To test, visit a site on the list and check that it is whitelisted.