### PR TITLE
add capitalone.ca to temp whitelist

### DIFF
--- a/trackers-whitelist-temporary.txt
+++ b/trackers-whitelist-temporary.txt
@@ -15,6 +15,7 @@ suntrust.com
 tdbank.com
 inlandbank.com
 bank.barclays.co.uk
+capitalone.ca
 capitalone.com
 onlinebanking.nationwide.co.uk
 nbarizona.com


### PR DESCRIPTION
Received feedback that capitalone.ca is breaking, so adding to list of whitelisted bank sites.