### PR TITLE
unblock other channeladvisor image gallery script

### DIFF
--- a/trackers-whitelist.txt
+++ b/trackers-whitelist.txt
@@ -83,6 +83,7 @@ omtrdc.net^$domain=canadiantire.ca
 ||googletagmanager.com/gtm.js$script,domain=account.bethesda.net
 ! unblock channeladvisor image cdn
 ||richmedia.channeladvisor.com/ImageDelivery/imageService^$image
+||richmedia.channeladvisor.com/ViewerDelivery^$script
 ! fix broken styles on bjs.com
 ||hlserve.com/Delivery/ClientPaths/Library/hook.js^$domain=bjs.com
 ! unbreak embedded marketo contact forms


### PR DESCRIPTION
richmedia.channeladvisor.com/.. seems to be used by a lot of ecommerce sites. We'd previously whitelisted their image cdn to fix bjs.com. This rule allows the associated gallery script.

URL is: https://www.costco.com/LG-6.3CuFt-INDUCTION-Slide-in-Range-with-ProBake-Convection.product.100341932.html

Before:
![image](https://user-images.githubusercontent.com/4481594/40335906-378d656e-5d34-11e8-841b-b912ff1879aa.png)

After:
![image](https://user-images.githubusercontent.com/4481594/40335915-3f7ea152-5d34-11e8-94bf-f32fad5afef9.png)
