### PR TITLE
Fix audio stream on ijpr.org

### DIFF
--- a/trackers-whitelist.txt
+++ b/trackers-whitelist.txt
@@ -92,6 +92,8 @@ omtrdc.net^$domain=canadiantire.ca
 ||marketo.com/index.php/leadCapture/save2^$xmlhttprequest
 ! fix search and image loading in safari
 ||script.ioam.de/iam.js$domain=ebay-kleinanzeigen.de
+! unbreak audio stream in safari
+||googletagservices.com/tag/js/gpt.js$script,domain=ijpr.org
 
 ! ###################################################
 ! #      End of manually added filter section       #


### PR DESCRIPTION
This site is making multiple requests to fetch gpt.js, and our surrogate response is breaking the radio stream (in safari only!). Whitelist gpt request on site to fix radio stream.

URL is: http://ijpr.org/post/oregon-legislature-approves-gov-kate-browns-tax-break-business