### PR TITLE
Add td to list of whitelisted bank sites

### DIFF
--- a/trackers-whitelist-temporary.txt
+++ b/trackers-whitelist-temporary.txt
@@ -20,3 +20,4 @@ capitalone.com
 onlinebanking.nationwide.co.uk
 nbarizona.com
 sberbank.ru
+td.com


### PR DESCRIPTION
As previously mentioned, we are whitelisting banking websites for which we have received breakage reports because they use legitimate fingerprinting to verify users' authenticity. This PR simply adds td.com to the list of sites where we do not block this type of activity.