### PR TITLE
Fix handful of sites, tighten up whitelist rule for apstag.js, unblock embedded salesforce assets

### DIFF
--- a/trackers-whitelist.txt
+++ b/trackers-whitelist.txt
@@ -26,10 +26,12 @@
 ||global.fncstatic.com
 ||s1.wp.com
 ||contextual.media.net/bidexchange.js^$domain=nytimes.com
-||google-analytics.com/analytics.js$domain=raspberrypi.org
+||google-analytics.com/analytics.js$domain=raspberrypi.org|localizahertz.com
 ||s3.amazonaws.com
+! unblock embedded polls
 ||static.polldaddy.com
 ||i.polldaddy.com
+||polldaddy.com^$script,image
 ||cdn.sporting.digitaljump.xyz
 ! causes the page to infinitely refresh on canadiantire.ca
 ||omtrdc.net^$domain=canadiantire.ca
@@ -56,14 +58,13 @@
 ||adnxs.com^$domain=bild.de
 ||chefkoch-cdn.de^$domain=chefkoch.de
 ||youtube.com^$script,stylesheet
-||ad.doubleclick.net/ddm/ad/$image,domain=spiegel.de
 ! unbreak 247 chat support
 ||d1af033869koo7.cloudfront.net/*/247px.js$script
 ||api.247-inc.net
 ! unbreak mailchimp subscription forms
 ||list-manage.com/subscribe
-! blocking this was breaking video players on dozens of network tv sites
-||c.amazon-adsystem.com/aax2/apstag.js
+! network tv sites use this script as an adblock sign
+||c.amazon-adsystem.com/aax2/apstag.js$domain=history.com|aetv.com|mylifetime.com|fyi.tv
 ! many sites use maps and stylesheets hosted on developers.google.com
 ||developers.google.com/maps^$stylesheet,script
 ||ib.adnxs.com/ut^$domain=aftonbladet.se
@@ -78,14 +79,11 @@
 ! fix sites built on wishabi/flipp
 ||images.wishabi.net^$image
 ||f.wishabi.net^$xmlhttprequest,image
-||tt.omtrdc.net^$script,domain=delltechnologiesworld.com
-||2o7.net^$image,domain=tennislink.usta.com|kiplinger.com
-! temporarily whitelist gpt on theatlantic to avoid paywall.
-! will revisit when solvable by script injection.
-||googletagservices.com/tag/js/gpt.js^$domain=theatlantic.com
-||moatads.com/freewheel*/MoatFreeWheelJSPEM.js^$domain=tntdrama.com
+||tt.omtrdc.net/cdn/target.js$script,domain=delltechnologiesworld.com|disneyvacationclub.disney.go.com
+||2o7.net^$image,domain=tennislink.usta.com|kiplinger.com|dunesvillage.com
+||moatads.com/freewheel*/MoatFreeWheelJSPEM.js^$domain=tntdrama.com|nba.com
 ! blocking googletagmanager breaks login form on bethesda.net
-||googletagmanager.com/gtm.js$script,domain=account.bethesda.net
+||googletagmanager.com/gtm.js$domain=account.bethesda.net|southbankresearch.com|redballoon.com.au
 ! unblock channeladvisor image cdn and image slideshows
 ||richmedia.channeladvisor.com/ImageDelivery/imageService^$image
 ||richmedia.channeladvisor.com/ViewerDelivery^$script,stylesheet
@@ -98,19 +96,34 @@
 ||marketo.com/index.php/leadCapture/save2^$xmlhttprequest
 ! fix search and image loading in safari
 ||script.ioam.de/iam.js$domain=ebay-kleinanzeigen.de
-! unbreak audio stream in safari
-||googletagservices.com/tag/js/gpt.js$script,domain=ijpr.org
-! unbreak search on buienradar
-||googletagservices.com/tag/js/gpt.js$domain=buienradar.nl
-! unbreak styles and comments on championat.com
-||palacesquare.rambler.ru^$image,stylesheet,domain=championat.com
-||comments.rambler.ru^$script,domain=championat.com
+! unbreak audio stream in safari, unbreak search on buienradar
+||googletagservices.com/tag/js/gpt.js$domain=ijpr.org|buienradar.nl|theatlantic.com
+! unbreak styles and comments on championat.com and lenta.ru
+||palacesquare.rambler.ru^$image,stylesheet,domain=championat.com|lenta.ru
+||comments.rambler.ru^$script,domain=championat.com|lenta.ru
 ! unbreak videos on thechive.com
 ||acdn.adnxs.com/video^$script,domain=thechive.com
 ! unbreak streaming video on cbsnews.com
-||c.evidon.com^$script,domain=cbsnews.com
+||c.evidon.com^$script,domain=cbsnews.com|etonline.com
 ! unbreak 7eleven rewards login
 ||cdn.mxpnl.com/libs/mixpanel-2-latest.min.js$domain=7-eleven.ca
+! unblock intercom.io support chat everywhere
+||intercom.io
+||doubleclick.net/instream/ad_status.js$script,domain=investing.com
+! pixel used to trigger adblock wall on spiegel.de and others
+||doubleclick.net/ddm/$image
+! unblock support chat on tracfone.com
+||inq.com^$domain=tracfone.com
+! fix gifs on thechive.com
+||adnxs.com/jpt^$script,domain=thechive.com
+||buysellads.com/ac/bsa.js$domain=whalesrule.tumblr.com
+||omtrdc.net/b/ss^$image,domain=mercuryinsurance.com
+! unblock ecommerce assets on rockstarwarehouse.com and others
+||digitalriver.com/DRHM/Storefront^$script,stylesheet,image
+! unblock images served on salesforce support sites such as support.ubi.com
+||force.com/servlet/servlet.ImageServer^$image
+||salesforce.com/servlet/servlet.ImageServer^$image
+||ad.crwdcntrl.net/*/callback=jsonp_callback$script,domain=weather.com
 
 ! ###################################################
 ! #      End of manually added filter section       #

--- a/trackers-whitelist.txt
+++ b/trackers-whitelist.txt
@@ -83,7 +83,7 @@
 ||2o7.net^$image,domain=tennislink.usta.com|kiplinger.com|dunesvillage.com
 ||moatads.com/freewheel*/MoatFreeWheelJSPEM.js^$domain=tntdrama.com|nba.com
 ! blocking googletagmanager breaks login form on bethesda.net
-||googletagmanager.com/gtm.js$domain=account.bethesda.net|southbankresearch.com|redballoon.com.au
+||googletagmanager.com/gtm.js$domain=account.bethesda.net|southbankresearch.com|redballoon.com.au|wrh.noaa.gov
 ! unblock channeladvisor image cdn and image slideshows
 ||richmedia.channeladvisor.com/ImageDelivery/imageService^$image
 ||richmedia.channeladvisor.com/ViewerDelivery^$script,stylesheet

--- a/trackers-whitelist.txt
+++ b/trackers-whitelist.txt
@@ -120,9 +120,10 @@
 ||omtrdc.net/b/ss^$image,domain=mercuryinsurance.com
 ! unblock ecommerce assets on rockstarwarehouse.com and others
 ||digitalriver.com/DRHM/Storefront^$script,stylesheet,image
-! unblock images served on salesforce support sites such as support.ubi.com
-||force.com/servlet/servlet.ImageServer^$image
-||salesforce.com/servlet/servlet.ImageServer^$image
+! unblock embedded salesforce assets
+||force.com^$script,stylesheet,image,xmlhttprequest,subdocument
+||salesforce.com^$script,stylesheet,image,xmlhttprequest,subdocument
+||salesforceliveagent.com^$script,xmlhttprequest,subdocument
 ||ad.crwdcntrl.net/*/callback=jsonp_callback$script,domain=weather.com
 
 ! ###################################################


### PR DESCRIPTION
Review: @jdorweiler 

Site fixes contained in this PR:
- unblock intercom.io globally
- unblock doubleclick.net/ddm/$image globally (commonly used as anti-adblock bait)
- https://redballoon.com.au entire site
- https://investing.com adblock wall
- https://spiegel.de adblock wall
- https://www.tracfone.com/techsupport support chat
- https://www.etonline.com/media/video/a_timeline_of_ben_affleck_alcohol_addled_past-213017
- https://thechive.com/2018/08/27/monday-hits-me-right-in-the-fails-2/ video stream
- https://whalesrule.tumblr.com/ entire site
- https://payment.mercuryinsurance.com/payments/stateSelection broken form
- http://www.nba.com/video/2018/08/09/lebron-james-first-laker-workout video stream
- https://www.dunesvillage.com/reservations/?checkin=09%2F01%2F2018&checkout=09%2F02%2F2018&rooms=1&adults=2&children=0&id=434&accomid=434&IEcacheBuster=1254344288312&showGDMain=1&clientName=dunesvillageresort&JSrefLoc=&JSbookedOnrefLoc=&calStartDate=&calCutOffDate=&calNumberOfNights=1&daysForwarded=0&defaultDaySpan=1#/room broken click events
- https://disneyvacationclub.disney.go.com/sign-in/?appRedirect=/home/ redirect loop
- https://www.rockstarwarehouse.com/store/tk2rstar/en_IE/home/currency.EUR/?# broken js
- https://www.mariowiki.com/Main_Page community poll
- https://www.localizahertz.com/brasil/pt-br/reserva?codigoCultura=pt-br&nomePaisResidencia=brasil&codigoLocalizaAgenciaRetirada=AAGIB&_dataHoraRetirada=29-09-2018+10%3A00&codigoLocalizaAgenciaDevolucao=AAGIB&_dataHoraDevolucao=30-09-2018+10%3A00&codigoPromocional=null&isChange=false&solicitarMotorista=False&usarPontosFidelidade=False&ehCodigoPromocionalCriptografado broken click events
- https://www.southbankresearch.com/ broken carousel
- https://support.ubi.com/es-ES/Faqs/000027228/Gestionar-el-Ubisoft-Club-los-amigos-Uplay images not loading
- https://weather.com/ intermittently broken search
- https://lenta.ru/ entire site
- http://my.wgu.edu/courses/course/4360001/course-material live chat and side bar (Fix https://github.com/duckduckgo/duckduckgo-privacy-extension/issues/297. After some investigation, blocking salesforce requests in general causes a lot of breakage for little to no benefit. Easylist and ubo don't even block salesforce, and disconnect includes it in the 'content' section. I think it makes sense to whitelist globally)
- Tightened up the apstag.js whitelist rule since it's so prevalent. Now it is only whitelisted on sites where we know it's an issue.