### PR TITLE
remove sites from temporary whitelist that are no longer issues.

### DIFF
--- a/trackers-whitelist-temporary.txt
+++ b/trackers-whitelist-temporary.txt
@@ -1,8 +1,3 @@
-messenger.com
-redmart.com
-wrh.noaa.gov
-wwwnew.testout.com
-idnes.cz
 calbanktrust.com
 fidelity.com
 vanguard.com


### PR DESCRIPTION
I went through and tested the remaining items on the temporary whitelist that aren't banks. Looks like all of them are fully functional now, so I'm removing them from the temporary whitelist.