### PR TITLE
unblock embedded mailchimp images

### DIFF
--- a/trackers-whitelist.txt
+++ b/trackers-whitelist.txt
@@ -125,6 +125,8 @@
 ||salesforce.com^$script,stylesheet,image,xmlhttprequest,subdocument
 ||salesforceliveagent.com^$script,xmlhttprequest,subdocument
 ||ad.crwdcntrl.net/*/callback=jsonp_callback$script,domain=weather.com
+! unblock images embedded in mailchimp emails
+||gallery.mailchimp.com^$image
 
 ! ###################################################
 ! #      End of manually added filter section       #


### PR DESCRIPTION
A lot of email services such as protonmail load remote images in emails, unlike gmail which creates their own cached version. We're erroneously blocking mailchimp images due to us identifying mailchimp as a tracker. This just whitelists the path they use to serve images embedded in emails.

Before: 
![image](https://user-images.githubusercontent.com/4481594/47125997-634ee200-d254-11e8-98a2-feb1117d6fca.png)

After: 
![image](https://user-images.githubusercontent.com/4481594/47126016-7c579300-d254-11e8-90ab-518e20c0bfa7.png)


