### PR TITLE
add gmail to temp whitelist

### DIFF
--- a/trackers-whitelist-temporary.txt
+++ b/trackers-whitelist-temporary.txt
@@ -19,3 +19,4 @@ td.com
 ameritrade.com
 mail.google.com
 gmail.com
+accounts.google.com

--- a/trackers-whitelist-temporary.txt
+++ b/trackers-whitelist-temporary.txt
@@ -17,3 +17,5 @@ nbarizona.com
 sberbank.ru
 td.com
 ameritrade.com
+mail.google.com
+gmail.com


### PR DESCRIPTION
There have been some reports of the extension breaking gmail. Adding it to the temp whitelist until we can figure out what's going on. 