### PR TITLE
expand whitelisting gtm on bethesda.net

### DIFF
--- a/trackers-whitelist.txt
+++ b/trackers-whitelist.txt
@@ -82,8 +82,8 @@
 ||tt.omtrdc.net/cdn/target.js$script,domain=delltechnologiesworld.com|disneyvacationclub.disney.go.com
 ||2o7.net^$image,domain=tennislink.usta.com|kiplinger.com|dunesvillage.com
 ||moatads.com/freewheel*/MoatFreeWheelJSPEM.js^$domain=tntdrama.com|nba.com
-! blocking googletagmanager breaks login form on bethesda.net
-||googletagmanager.com/gtm.js$domain=account.bethesda.net|southbankresearch.com|redballoon.com.au|wrh.noaa.gov
+! blocking googletagmanager breaks multiple features on bethesda.net
+||googletagmanager.com/gtm.js$domain=bethesda.net|southbankresearch.com|redballoon.com.au|wrh.noaa.gov
 ! unblock channeladvisor image cdn and image slideshows
 ||richmedia.channeladvisor.com/ImageDelivery/imageService^$image
 ||richmedia.channeladvisor.com/ViewerDelivery^$script,stylesheet


### PR DESCRIPTION
Was breaking game version selector on https://fallout.bethesda.net/games/fallout-76.