### PR TITLE
Fix video streaming on foxnews

### DIFF
--- a/trackers-whitelist.txt
+++ b/trackers-whitelist.txt
@@ -127,6 +127,8 @@
 ||ad.crwdcntrl.net/*/callback=jsonp_callback$script,domain=weather.com
 ! unblock images embedded in mailchimp emails
 ||gallery.mailchimp.com^$image
+! unbreak videos on foxnews
+||acdn.adnxs.com/prebid/*/prebid.js$domain=foxnews.com|foxbusiness.com
 
 
 ! ###################################################


### PR DESCRIPTION
To test, try a few videos:
https://video.foxnews.com/v/6028688814001/#sp=show-clips
https://video.foxbusiness.com/v/6028724742001/#sp=show-clips

They should load now
