### PR TITLE
add jetblue to broken site list

### DIFF
--- a/trackers-whitelist-temporary.txt
+++ b/trackers-whitelist-temporary.txt
@@ -19,3 +19,4 @@ td.com
 ameritrade.com
 santander.com
 santander.co.uk
+jetblue.com


### PR DESCRIPTION
Broken links in header on jetblue.com