### PR TITLE
Remove temp whitelist rules that are no longer necessary

### DIFF
--- a/trackers-whitelist-temporary.txt
+++ b/trackers-whitelist-temporary.txt
@@ -19,12 +19,3 @@ td.com
 ameritrade.com
 santander.com
 santander.co.uk
-jetblue.com
-1000bulbs.com
-entirelypets.com
-drudgereport.com
-healthypets.com
-washingtonpost.com
-telequebec.tv
-channel4.com
-sueddeutsche.de


### PR DESCRIPTION
Confirmed that all of these domains are either fixed now or are wontfix issues (eg paywalls).