### PR TITLE
Safe-list swiftype.com

### DIFF
--- a/trackers-whitelist.txt
+++ b/trackers-whitelist.txt
@@ -129,6 +129,8 @@
 ||gallery.mailchimp.com^$image
 ! unbreak videos on foxnews
 ||acdn.adnxs.com/prebid/*/prebid.js$domain=foxnews.com|foxbusiness.com
+! unblock site search toolbars powered by Elastic's Swiftype
+||*.api.swiftype.com
 
 
 ! ###################################################

--- a/trackers-whitelist.txt
+++ b/trackers-whitelist.txt
@@ -132,6 +132,7 @@
 ! unblock site search toolbars powered by Elastic's Swiftype
 ||api.swiftype.com
 ||*.api.swiftype.com
+||search-api.swiftype.com
 
 
 ! ###################################################

--- a/trackers-whitelist.txt
+++ b/trackers-whitelist.txt
@@ -130,6 +130,7 @@
 ! unbreak videos on foxnews
 ||acdn.adnxs.com/prebid/*/prebid.js$domain=foxnews.com|foxbusiness.com
 ! unblock site search toolbars powered by Elastic's Swiftype
+||api.swiftype.com
 ||*.api.swiftype.com
 
 


### PR DESCRIPTION
Hi there!

[Swiftype](https://swiftype.com/) is a paid for site search SaaS from Elastic, the creators of Elasticsearch, Logstash, Kibana etc.

It does no tracking as it's a paid service with no advertising element, and you can read more [in the GDPR and privacy policy FAQ](https://swiftype.com/privacy-and-gdpr-faq).

Several of our customer's customers are unable to use the site search functionality, specifically those powered by including our hosted JavaScript files directly on their site and making API calls from the browser to our API (`*.api.swiftype.com`).

This adds a safe-list for calls to the Swiftype API.

Thanks! :sparkling_heart: